### PR TITLE
更新 Readme 中的使用方法

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,14 @@
 
 ### 使用方法
 
+​		在 iSmartAuto2 目录下打开终端，并输入以下命令安装依赖库
+
+```shell
+pip install -r .\requirements.txt
+```
+
+​		如果提示“pyppeteer 0.2.4 requires websockets<9.0,>=8.1, but you have websockets xxx which is incompatible”，请使用 `pip uninstall websockets` 卸载 websocket 库，然后使用 `pip install websockets==8.1` 安装 websocket 8.1 版本。这之后请不要再使用上面的命令安装依赖库。
+
 &emsp;&emsp;修改 iSmart 的启动快捷方式，增加参数 `--remote-debugging-port=9222`（如下图），**然后启动 iSmart 客户端并保持登录**
 
 ![](images/edit-lnk.png)


### PR DESCRIPTION
增加了安装正确版本依赖库的方法。
本项目有 requirements.txt 描述依赖库，但没有提及安装依赖库的事情，给不常用 Python 的同学带来了一点麻烦。
另外，pip在依照txt安装依赖库的时候会安装 websockets 10.1 版本而非 8.1 版本，实测如果使用 10.1 版本就会造成 issue 中的几种 exception，故提醒降级。